### PR TITLE
Tested SerialTransfer library

### DIFF
--- a/docs/libraries.html
+++ b/docs/libraries.html
@@ -9301,7 +9301,7 @@
       <td>SerialToWifi</td><td>serialtowifi</td><td>pac-serialtowifi</td><td>all</td><td>make failed</td><td> </td>
     </tr>
     <tr>
-      <td>SerialTransfer</td><td>serialtransfer</td><td>pac-serialtransfer</td><td>all</td><td>OK</td><td> </td>
+      <td>SerialTransfer</td><td>serialtransfer</td><td>pac-serialtransfer</td><td>all</td><td>OK</td><td>Passed</td>
     </tr>
     <tr>
       <td>SerialUI</td><td>serialui</td><td>pac-serialui</td><td>all</td><td>make failed</td><td> </td>


### PR DESCRIPTION
I had a chance to test the SerialTransfer library and can confirm that it works on the Pico. Updated the "test" column to reflect this.

I noticed that after my last change to this list was merged, the page failed to build. Is there something else I need to do in order to update this list?